### PR TITLE
[Android] Fix progress bar not being cleanly removed

### DIFF
--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
@@ -43,7 +43,7 @@ public class SplashScreenPlugin extends Plugin {
     // Show and update progress of progress bar.
     @PluginMethod
     public void updateProgress(final PluginCall call) {
-        splashScreen.updateProgress(getActivity(), call.getFloat("progress", (float) 0));
+        splashScreen.updateProgress(call.getFloat("progress", (float) 0));
         call.resolve();
     }
 


### PR DESCRIPTION
There was an issue where if the splash screen was not hidden properly before using the app (e.g. Capacitor redirect without hiding splash/autohide splash), UI elements were unclickable/cannot be discovered.