### PR TITLE
Merge splash screen animation and progress bar patches onto Capacitor 5

### DIFF
--- a/splash-screen/README.md
+++ b/splash-screen/README.md
@@ -178,7 +178,7 @@ In `capacitor.config.json`:
 In `capacitor.config.ts`:
 
 ```ts
-/// <reference types="@capacitor/splash-screen" />
+/// <reference types="@freelancercom/splash-screen" />
 
 import { CapacitorConfig } from '@capacitor/cli';
 

--- a/splash-screen/README.md
+++ b/splash-screen/README.md
@@ -87,6 +87,39 @@ For iOS, `iosSpinnerStyle` has the following options:
 
 To set the color of the spinner use `spinnerColor`, values are either `#RRGGBB` or `#RRGGBBAA`.
 
+## Animated Splash Screen
+### iOS
+If you want to have an animated splash screen on iOS, set `animated` to `true`, and `launchAnimationDuration` to the desired animation length in milliseconds in your [Capacitor configuration file] (https://capacitorjs.com/docs/config).
+
+Once done, you can add the splash screen assets into your app's `Assets.xcassets` file inside a folder called `Splash`. Each frame should be placed in order, with `Splash_xx` (where xx is the number it belongs to in sequence, e.g. splash_1.png, splash_2.png, ...).
+
+## Android
+If you want to have an animated splash screen on Android, create a `splash.xml` in your app's `res/drawable` folder with an animation list showing the location and duration of each frame.
+
+For example:
+
+```
+<?xml version="1.0" encoding="utf-8"?>
+<animation-list xmlns:android="http://schemas.android.com/apk/res/android" android:oneshot="false">
+	<item android:duration="22" android:drawable="@drawable/splash_1">
+	</item>
+	<item android:duration="22" android:drawable="@drawable/splash_2">
+	</item>
+	<item android:duration="22" android:drawable="@drawable/splash_3">
+	</item>
+	<item android:duration="22" android:drawable="@drawable/splash_4">
+	</item>
+	<item android:duration="22" android:drawable="@drawable/splash_5">
+	</item>
+	<item android:duration="22" android:drawable="@drawable/splash_6">
+	</item>
+	<item android:duration="22" android:drawable="@drawable/splash_7">
+	</item>
+</animation-list>
+```
+
+Be sure to correctly scale your images as well, as not scaling them may cause significant performance degradation when loading your app.
+
 ## Configuration
 
 <docgen-config>
@@ -110,6 +143,8 @@ These config values are available:
 | **`splashImmersive`**           | <code>boolean</code>                                                                                                          | Hide the status bar and the software navigation buttons on the Splash Screen. Doesn't work on launch when using the Android 12 API. Only available on Android.                                                                                          |                     | 1.0.0 |
 | **`layoutName`**                | <code>string</code>                                                                                                           | If `useDialog` is set to true, configure the Dialog layout. If `useDialog` is not set or false, use a layout instead of the ImageView. Doesn't work on launch when using the Android 12 API. Only available on Android.                                 |                     | 1.1.0 |
 | **`useDialog`**                 | <code>boolean</code>                                                                                                          | Use a Dialog instead of an ImageView. If `layoutName` is not configured, it will use a layout that uses the splash image as background. Doesn't work on launch when using the Android 12 API. Only available on Android.                                |                     | 1.1.0 |
+| **`animated`**                  | <code>boolean</code>                                                                                                          | Animate the splash screen using a series of image files.                                                                                                                                                                                                |                     | 1.2.3 |
+| **`launchAnimationDuration`**   | <code>number</code>                                                                                                           | Play the multiple frames across the amount of milliseconds specified.                                                                                                                                                                                   |                     | 1.2.3 |
 
 ### Examples
 
@@ -132,7 +167,9 @@ In `capacitor.config.json`:
       "splashFullScreen": true,
       "splashImmersive": true,
       "layoutName": "launch_screen",
-      "useDialog": true
+      "useDialog": true,
+      "animated": true,
+      "launchAnimationDuration": 3000
     }
   }
 }
@@ -162,6 +199,8 @@ const config: CapacitorConfig = {
       splashImmersive: true,
       layoutName: "launch_screen",
       useDialog: true,
+      animated: true,
+      launchAnimationDuration: 3000,
     },
   },
 };
@@ -198,6 +237,7 @@ This plugin will use the following project variables (defined in your app's `var
 <docgen-index>
 
 * [`show(...)`](#show)
+* [`updateProgress(...)`](#updateprogress)
 * [`hide(...)`](#hide)
 * [Interfaces](#interfaces)
 
@@ -219,6 +259,23 @@ Show the splash screen
 | **`options`** | <code><a href="#showoptions">ShowOptions</a></code> |
 
 **Since:** 1.0.0
+
+--------------------
+
+
+### updateProgress(...)
+
+```typescript
+updateProgress(options: UpdateProgressOptions) => Promise<void>
+```
+
+Update progress of splash screen
+
+| Param         | Type                                                                    |
+| ------------- | ----------------------------------------------------------------------- |
+| **`options`** | <code><a href="#updateprogressoptions">UpdateProgressOptions</a></code> |
+
+**Since:** 1.2.3
 
 --------------------
 
@@ -251,6 +308,13 @@ Hide the splash screen
 | **`fadeInDuration`**  | <code>number</code>  | How long (in ms) to fade in.                                        | <code>200</code>  | 1.0.0 |
 | **`fadeOutDuration`** | <code>number</code>  | How long (in ms) to fade out.                                       | <code>200</code>  | 1.0.0 |
 | **`showDuration`**    | <code>number</code>  | How long to show the splash screen when autoHide is enabled (in ms) | <code>3000</code> | 1.0.0 |
+
+
+#### UpdateProgressOptions
+
+| Prop           | Type                | Description                     | Since |
+| -------------- | ------------------- | ------------------------------- | ----- |
+| **`progress`** | <code>number</code> | Set percentage of progress bar. | 1.2.3 |
 
 
 #### HideOptions

--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenConfig.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenConfig.java
@@ -18,6 +18,8 @@ public class SplashScreenConfig {
     private ScaleType scaleType = ScaleType.FIT_XY;
     private boolean usingDialog = false;
     private String layoutName;
+    // This is used to determine whether a series of images should be used to animate the splash screen.
+    private boolean animated = false;
 
     public Integer getBackgroundColor() {
         return backgroundColor;
@@ -117,6 +119,16 @@ public class SplashScreenConfig {
 
     public void setLayoutName(String layoutName) {
         this.layoutName = layoutName;
+    }
+
+    // This is used to read the config for whether the splash screen should be animated.
+    public boolean getAnimated() {
+        return animated;
+    }
+
+    // This is used to set the config for whether the splash screen should be animated.
+    public void setAnimated(Boolean animated) {
+        this.animated = animated;
     }
 
     public Integer getLaunchFadeOutDuration() {

--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
@@ -44,6 +44,13 @@ public class SplashScreenPlugin extends Plugin {
         );
     }
 
+    // Show and update progress of progress bar.
+    @PluginMethod
+    public void updateProgress(final PluginCall call) {
+        splashScreen.updateProgress(call.getFloat("progress", (float) 0));
+        call.resolve();
+    }
+
     @PluginMethod
     public void hide(PluginCall call) {
         if (config.isUsingDialog()) {
@@ -160,6 +167,12 @@ public class SplashScreenPlugin extends Plugin {
         if (getConfig().getString("layoutName") != null) {
             config.setLayoutName(getConfig().getString("layoutName"));
         }
+
+        // This reads the Capacitor config for whether the splash screen should be animated.
+        // Defaults to false.
+        Boolean animated = getConfig().getBoolean("animated", false);
+        // Set the config that the splash screen should/should not be animated.
+        config.setAnimated(animated);
 
         return config;
     }

--- a/splash-screen/ios/Plugin/SplashScreen.swift
+++ b/splash-screen/ios/Plugin/SplashScreen.swift
@@ -5,7 +5,14 @@ import Capacitor
 
     var parentView: UIView
     var viewController = UIViewController()
+    // This image view / images are used to show the series of images for an animation.
+    var imageView = UIImageView()
+    var image: UIImage?
     var spinner = UIActivityIndicatorView()
+    // Used for `updateProgress` function.
+    // Progress bar will only be shown when `updateProgress` is called by web app.
+    var progressBar = UIProgressView()
+    var progressBarVisible = false
     var config: SplashScreenConfig = SplashScreenConfig()
     var hideTask: Any?
     var isVisible: Bool = false
@@ -17,6 +24,21 @@ import Capacitor
 
     public func showOnLaunch() {
         buildViews()
+        
+        // This has been moved here to prevent the LaunchScreen ==> WebView ==> SplashScreen flash.
+        if let backgroundColor = config.backgroundColor {
+            viewController.view.backgroundColor = backgroundColor
+        }
+        
+        parentView.addSubview(viewController.view)
+
+        // If the config says to animate.
+        if config.animated {
+            // Add the animated imageview across to the main view for viewing.
+            // Done with the subview to ensure the fade is done evenly.
+            viewController.view.addSubview(imageView)
+        }
+        
         if self.config.launchShowDuration == 0 {
             return
         }
@@ -31,6 +53,32 @@ import Capacitor
         self.showSplash(settings: settings, completion: completion, isLaunchSplash: false)
     }
 
+    // This function when called will automatically add a progress bar to the splash screen
+    // if it is not available yet, and update the progress bar's progress.
+    public func updateProgress(percentage: Float) {
+        // Updating UI from main thread would cause issues hence a DispatchQueue is used.
+        // This is similar to the approach used by functions `showSplash` and `hideSplash`.
+        DispatchQueue.main.async { [weak self] in
+            guard let strongSelf = self else {
+                return
+            }
+            
+            // In the case the progress bar is not visible yet.
+            if !strongSelf.progressBarVisible {
+                // Make the progress bar's progress gray.
+                strongSelf.progressBar.tintColor = .gray
+                // Add it to the parent view so it can be shown.
+                strongSelf.parentView.addSubview(strongSelf.progressBar)
+                // Make the progress bar show in the middle of the screen (x) but 75% down (y) to allow for the logo to not be blocked.
+                strongSelf.progressBar.frame = CGRect(x: strongSelf.parentView.frame.midX - (strongSelf.parentView.frame.midX / 2), y: strongSelf.parentView.frame.midY * 1.25, width: strongSelf.parentView.frame.midX, height: 0)
+                strongSelf.progressBarVisible = true
+            }
+            
+            // Update the progress.
+            strongSelf.progressBar.setProgress(percentage / 100, animated: true)
+        }
+    }
+
     public func hide(settings: SplashScreenSettings) {
         hideSplash(fadeOutDuration: settings.fadeOutDuration, isLaunchSplash: false)
     }
@@ -40,10 +88,7 @@ import Capacitor
             guard let strongSelf = self else {
                 return
             }
-            if let backgroundColor = strongSelf.config.backgroundColor {
-                strongSelf.viewController.view.backgroundColor = backgroundColor
-            }
-
+            
             if strongSelf.config.showSpinner {
                 if let style = strongSelf.config.spinnerStyle {
                     strongSelf.spinner.style = style
@@ -54,8 +99,6 @@ import Capacitor
                 }
             }
 
-            strongSelf.parentView.addSubview(strongSelf.viewController.view)
-
             if strongSelf.config.showSpinner {
                 strongSelf.parentView.addSubview(strongSelf.spinner)
                 strongSelf.spinner.centerXAnchor.constraint(equalTo: strongSelf.parentView.centerXAnchor).isActive = true
@@ -65,6 +108,7 @@ import Capacitor
             strongSelf.parentView.isUserInteractionEnabled = false
 
             UIView.transition(with: strongSelf.viewController.view, duration: TimeInterval(Double(settings.fadeInDuration) / 1000), options: .curveLinear, animations: {
+                // The animated imageview (if any) should fade in evenly with this.
                 strongSelf.viewController.view.alpha = 1
 
                 if strongSelf.config.showSpinner {
@@ -87,6 +131,19 @@ import Capacitor
         }
     }
 
+    // Creates an array of UIImage to play a sequence of images as an animation.
+    // Ref: https://blog.devgenius.io/how-to-animate-your-images-in-swift-ios-swift-guide-64de30ea616b
+    func animatedImages(for name: String) -> [UIImage] {
+        var i = 0
+        var images = [UIImage]()
+
+        while let image = UIImage(named: "\(name)/\(name)_\(i)") {
+            images.append(image)
+            i += 1
+        }
+        return images
+    }
+
     private func buildViews() {
         let storyboardName = Bundle.main.infoDictionary?["UILaunchStoryboardName"] as? String ?? "LaunchScreen"
         if let vc = UIStoryboard(name: storyboardName.replacingOccurrences(of: ".storyboard", with: ""), bundle: nil).instantiateInitialViewController() {
@@ -102,6 +159,18 @@ import Capacitor
             spinner.translatesAutoresizingMaskIntoConstraints = false
             spinner.startAnimating()
         }
+
+        // If the app config says to animate.
+        if config.animated {
+            // Use the first image of the image set as a placeholder until it animates.
+            imageView.image = UIImage(named: "Splash/Splash_0")
+            // Create the list of images to make it animated.
+            imageView.animationImages = self.animatedImages(for: "Splash")
+            // Set how long to play the images over. e.g. if it's set to 3 sec, then play all images over 3 sec.
+            imageView.animationDuration = TimeInterval(Double(config.launchAnimationDuration) / 1000)
+            // Start the animation.
+            imageView.startAnimating()
+        }
     }
 
     private func tearDown() {
@@ -111,6 +180,19 @@ import Capacitor
 
         if config.showSpinner {
             spinner.removeFromSuperview()
+        }
+      
+        // If the splash screen is animated.
+        if config.animated {
+            // Remove it from the view.
+            imageView.removeFromSuperview()
+        }
+      
+        // In the case that the progress bar has been activated.
+        if self.progressBarVisible {
+            // Remove the progress bar.
+            progressBar.removeFromSuperview()
+            self.progressBarVisible = false
         }
     }
 
@@ -129,6 +211,14 @@ import Capacitor
 
         if let unwrappedWindow = window {
             viewController.view.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: unwrappedWindow.bounds.size)
+
+            // If config says it's to be animated.
+            if config.animated {
+                // Fit the image view to the screen.
+                imageView.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: window!.bounds.size)
+                // Ensure that the image fits the whole screen.
+                imageView.contentMode = .scaleAspectFit
+            }
         } else {
             CAPLog.print("Unable to find root window object for SplashScreen bounds. Please file an issue")
         }
@@ -147,10 +237,17 @@ import Capacitor
         if !isVisible { return }
         DispatchQueue.main.async {
             UIView.transition(with: self.viewController.view, duration: TimeInterval(Double(fadeOutDuration) / 1000), options: .curveLinear, animations: {
+                // ImageView for animated splash will fade with this.
                 self.viewController.view.alpha = 0
 
                 if self.config.showSpinner {
                     self.spinner.alpha = 0
+                }
+                
+                // In the case the progress bar has been added.
+                if self.progressBarVisible {
+                    // Make the progress bar invisible.
+                    self.progressBar.alpha = 0
                 }
             }) { (_: Bool) in
                 self.tearDown()

--- a/splash-screen/ios/Plugin/SplashScreenConfig.swift
+++ b/splash-screen/ios/Plugin/SplashScreenConfig.swift
@@ -8,4 +8,8 @@ public struct SplashScreenConfig {
     var launchShowDuration = 500
     var launchAutoHide = true
     let launchFadeInDuration = 0
+    // How long it should take to flick through all the images for an animation.
+    var launchAnimationDuration = 3000
+    // Whether a splash screen should be animated.
+    var animated = false
 }

--- a/splash-screen/ios/Plugin/SplashScreenPlugin.m
+++ b/splash-screen/ios/Plugin/SplashScreenPlugin.m
@@ -5,5 +5,7 @@
 // each method the plugin supports using the CAP_PLUGIN_METHOD macro.
 CAP_PLUGIN(SplashScreenPlugin, "SplashScreen",
            CAP_PLUGIN_METHOD(show, CAPPluginReturnPromise);
+           // Show and update progress of progress bar.
+           CAP_PLUGIN_METHOD(updateProgress, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(hide, CAPPluginReturnPromise);
 )

--- a/splash-screen/ios/Plugin/SplashScreenPlugin.swift
+++ b/splash-screen/ios/Plugin/SplashScreenPlugin.swift
@@ -26,6 +26,16 @@ public class SplashScreenPlugin: CAPPlugin {
 
     }
 
+    // Show and update progress of progress bar.
+    @objc public func updateProgress(_ call: CAPPluginCall) {
+        if let splash = splashScreen {
+            splash.updateProgress(percentage: call.getFloat("progress", 0))
+            call.resolve()
+        } else {
+            call.reject("Unable to hide Splash Screen")
+        }
+    }
+
     // Hide the splash screen
     @objc public func hide(_ call: CAPPluginCall) {
         if let splash = splashScreen {
@@ -76,6 +86,9 @@ public class SplashScreenPlugin: CAPPlugin {
 
         config.launchShowDuration = getConfig().getInt("launchShowDuration", config.launchShowDuration)
         config.launchAutoHide = getConfig().getBoolean("launchAutoHide", config.launchAutoHide)
+        config.animated = getConfig().getBoolean("animated", config.animated)
+        // Play the multiple image frames across the amount of milliseconds specified.
+        config.launchAnimationDuration = getConfig().getInt("launchAnimationDuration", config.launchAnimationDuration)
         return config
     }
 

--- a/splash-screen/package.json
+++ b/splash-screen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelancercom/splash-screen",
-  "version": "4.2.0-fork.0",
+  "version": "5.0.8-fork.0",
   "description": "The Splash Screen API provides methods for showing or hiding a Splash image.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/splash-screen/package.json
+++ b/splash-screen/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@capacitor/splash-screen",
-  "version": "4.2.0",
+  "name": "@freelancercom/splash-screen",
+  "version": "4.2.0-fork.0",
   "description": "The Splash Screen API provides methods for showing or hiding a Splash image.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/splash-screen/src/definitions.ts
+++ b/splash-screen/src/definitions.ts
@@ -174,6 +174,22 @@ declare module '@capacitor/cli' {
        * @example true
        */
       useDialog?: boolean;
+
+      /**
+       * Animate the splash screen using a series of image files.
+       *
+       * @since 1.2.3
+       * @example true
+       */
+      animated?: boolean;
+
+       /**
+       * Play the multiple frames across the amount of milliseconds specified.
+       *
+       * @since 1.2.3
+       * @example 3000
+       */
+      launchAnimationDuration?: number;
     };
   }
 }
@@ -208,6 +224,15 @@ export interface ShowOptions {
   showDuration?: number;
 }
 
+export interface UpdateProgressOptions {
+  /**
+   * Set percentage of progress bar.
+   *
+   * @since 1.2.3
+   */
+  progress: number;
+}
+
 export interface HideOptions {
   /**
    * How long (in ms) to fade out.
@@ -228,6 +253,12 @@ export interface SplashScreenPlugin {
    * @since 1.0.0
    */
   show(options?: ShowOptions): Promise<void>;
+  /**
+   * Update progress of splash screen
+   *
+   * @since 1.2.3
+   */
+  updateProgress(options: UpdateProgressOptions): Promise<void>;
   /**
    * Hide the splash screen
    *

--- a/splash-screen/src/web.ts
+++ b/splash-screen/src/web.ts
@@ -4,10 +4,16 @@ import type {
   HideOptions,
   ShowOptions,
   SplashScreenPlugin,
+  UpdateProgressOptions,
 } from './definitions';
 
 export class SplashScreenWeb extends WebPlugin implements SplashScreenPlugin {
   async show(_options?: ShowOptions): Promise<void> {
+    return undefined;
+  }
+
+  // Show and update progress of progress bar.
+  async updateProgress(_options?: UpdateProgressOptions): Promise<void> {
     return undefined;
   }
 


### PR DESCRIPTION
As title + bump version in package.json

Previously tested with a manual merge effectively of `5.x` into freelancer forked `3.x` and animation + progress bar worked on Android 11 and iOS. 

With this specific PR I tested that the animation works but due to what seems like unrelated factors I am unable to load the website (so cannot test the progress bar)